### PR TITLE
7-dont-exclude-other-languages-from-the-default-role

### DIFF
--- a/src/providers/prompt.rs
+++ b/src/providers/prompt.rs
@@ -6,7 +6,7 @@ use indoc::indoc;
 pub struct Prompt;
 
 impl Prompt {
-    pub const DEFAULT_ROLE: &str = "You are a senior Rust engineer";
+    pub const DEFAULT_ROLE: &str = "You are a senior engineer";
     pub const DEFAULT_DIRECTIVE: &str = indoc! {
         r#"Analyze this git diff and create a concise PR description. Focus on:
         - What changes were made (be specific but brief)


### PR DESCRIPTION
**PR Description:**

- The `DEFAULT_ROLE` field in the `Prompt` struct has been updated from "Senior Rust Engineer" to "Senior Engineer".
