### PR TITLE
Add --title flag to generate PR title instead of description

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ struct Args {
     config: PathBuf,
 
     /// Generate a PR title instead of description
-    #[arg(long)]
+    #[arg(short = 'T', long)]
     title: bool,
 
     /// Verbose mode (-v, -vv, -vvv)

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,10 @@ struct Args {
     #[arg(short = 'f', long = "config", global = true, default_value = default_config_string())]
     config: PathBuf,
 
+    /// Generate a PR title instead of description
+    #[arg(long)]
+    title: bool,
+
     /// Verbose mode (-v, -vv, -vvv)
     #[arg(short, action = clap::ArgAction::Count)]
     verbose: u8,
@@ -83,6 +87,7 @@ fn main() -> Result<()> {
         .maybe_head(args.commit2.clone())
         .maybe_role(profile.role.clone())
         .maybe_directive(profile.directive.clone())
+        .is_title(args.title)
         .build();
 
     let description = match profile.provider {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -15,6 +15,7 @@ pub struct Request {
     pub exclude: String,
     pub role: Option<String>,
     pub directive: Option<String>,
+    pub is_title: bool,
 }
 
 pub trait Provider {
@@ -30,6 +31,7 @@ pub trait Provider {
             request.exclude.as_str(),
             request.role.as_deref(),
             request.directive.as_deref(),
+            request.is_title,
         )?;
         trace!("Prompt:\n{prompt}");
         Ok(prompt)


### PR DESCRIPTION
- Add `--title` flag to generate a concise PR title instead of description
- Update prompt rendering to use different default directive for title vs description
- Add `DEFAULT_TITLE_DIRECTIVE` constant with instructions for generating a PR title

Key changes:
- New `--title` flag to switch between generating a PR title or description
- Title directive instructs to generate a concise title under 50 characters in imperative mood
- Description directive remains the same, instructing a brief multi-bullet summary under 150 words


-----------------------
First try PR desc:

Based on the provided diff, here is a concise PR description:

- Add `--title` flag to generate a PR title instead of description
- Update prompt rendering to use different default directive for title vs description
- Add `get_git_diff` function to `providers/prompt.rs` for reusability
- Update tests to handle new `is_title` parameter

This change introduces a new command-line option to generate a concise PR title adhering to best practices, such as using imperative mood and staying within the 50-character limit. It also refactors the prompt rendering logic to support different directives for title and description generation.