### PR TITLE
Update prompt text to clarify breaking changes section

### DIFF
--- a/src/providers/prompt.rs
+++ b/src/providers/prompt.rs
@@ -11,7 +11,7 @@ impl Prompt {
         r#"Analyze this git diff and create a concise PR description. Focus on:
         - What changes were made (be specific but brief)
         - Why these changes matter
-        - Any breaking changes or important notes
+        - Any breaking changes or important notes, assuming there are any. If not, don't mention it.
         Keep it under 150 words and use bullet points for clarity. Don't include implementation details unless critical.
         Don't unclude your own thought process. The output should be just the content of the PR summary."#
     };


### PR DESCRIPTION
- Updated the `Prompt` struct to include a new instruction for the PR description template
- The new instruction clarifies that breaking changes or important notes should only be mentioned if they exist
- This change helps keep the PR description more concise when there are no breaking changes or important notes

The update is a minor improvement to the existing PR description template, making it more clear and concise when there are no breaking changes or important notes to include.