### PR TITLE
12-use-default-commits-of-default-branch-and-head

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,73 @@
+use std::process::Command;
+
+use lazy_static::lazy_static;
+
+pub fn get_default_branch() -> &'static str {
+    lazy_static! {
+        static ref DEFAULT_BRANCH: String = Command::new("git")
+            .args(["remote", "show", "origin"])
+            .output()
+            .ok()
+            .and_then(|o| {
+                if o.status.success() {
+                    return parse_default_branch(&o.stdout);
+                }
+                None
+            })
+            .unwrap_or(String::from("HEAD"));
+    }
+
+    &DEFAULT_BRANCH
+}
+
+fn parse_default_branch(stdout: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .find(|l| l.trim().starts_with("HEAD branch: "))
+        .and_then(|l| l.split_once(": "))
+        .and_then(|(_, branch)| match branch.trim() {
+            "" => None,
+            branch => Some(String::from(branch)),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_parse_branch() {
+        let input_str = indoc! {
+            r#"* remote origin
+              Fetch URL: git@github.com:theelderbeever/prai-cli.git
+              Push  URL: git@github.com:theelderbeever/prai-cli.git
+              HEAD branch: main
+              Remote branches:
+                1-add-configuration-and-provider-support                                 tracked
+                main                                                                     tracked
+                refs/remotes/origin/5-update-dependencies                                stale (use 'git remote prune' to remove)
+                refs/remotes/origin/7-dont-exclude-other-languages-from-the-default-role stale (use 'git remote prune' to remove)
+              Local branches configured for 'git pull':
+                1-add-configuration-and-provider-support merges with remote 1-add-configuration-and-provider-support
+                main                                     merges with remote main
+              Local refs configured for 'git push':
+                1-add-configuration-and-provider-support pushes to 1-add-configuration-and-provider-support (up to date)
+                main                                     pushes to main                                     (local out of date)
+            "#
+        };
+
+        let branch = parse_default_branch(input_str.as_bytes());
+
+        assert_eq!(Some("main"), branch.as_deref());
+    }
+
+    #[test]
+    fn test_default_branch() {
+        let branch = get_default_branch();
+
+        assert_eq!("main", branch);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod git;
 pub mod providers;
 pub mod settings;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,10 @@ fn default_config_string() -> &'static str {
 #[command(name = "prai")]
 #[command(about = "Generate PR descriptions from git diffs using configurable AI providers")]
 struct Args {
-    #[arg(default_value = "HEAD")]
+    #[arg(default_value = prai::git::get_default_branch())]
     commit1: String,
+
+    #[arg(default_value = "HEAD")]
     commit2: Option<String>,
 
     #[arg(short, long, default_value = ":!*.lock")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ struct Args {
     commit1: String,
 
     #[arg(default_value = "HEAD")]
-    commit2: Option<String>,
+    commit2: String,
 
     #[arg(short, long, default_value = ":!*.lock")]
     exclude: String,
@@ -86,7 +86,7 @@ fn main() -> Result<()> {
     let request = Request::builder()
         .base(args.commit1.clone())
         .exclude(args.exclude.clone())
-        .maybe_head(args.commit2.clone())
+        .head(args.commit2.clone())
         .maybe_role(profile.role.clone())
         .maybe_directive(profile.directive.clone())
         .is_title(args.title)

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -11,7 +11,7 @@ use log::trace;
 #[derive(Builder, Debug)]
 pub struct Request {
     pub base: String,
-    pub head: Option<String>,
+    pub head: String,
     pub exclude: String,
     pub role: Option<String>,
     pub directive: Option<String>,
@@ -27,7 +27,7 @@ pub trait Provider {
     fn build_prompt(&self, request: &Request) -> Result<String> {
         let prompt = prompt::Prompt::render(
             request.base.as_str(),
-            request.head.as_deref(),
+            request.head.as_str(),
             request.exclude.as_str(),
             request.role.as_deref(),
             request.directive.as_deref(),


### PR DESCRIPTION
-Here's a concise PR description based on the provided git diff:

- Added a new `git` module to get the default branch from the Git remote
- Updated the `prai` command to use the default branch as the base commit by default
- Changed the `commit2` argument to be required and default to `HEAD`
- Improved error handling in the `Prompt::get_git_diff` function
- Added tests for the new `git` module and `Prompt::get_git_diff` function

This PR enhances the `prai` CLI by automatically detecting the default branch from the Git remote and using it as the base commit for generating PR descriptions. It also improves error handling and adds tests for the new functionality.
