### PR TITLE
9-better-prompting

### DIFF
--- a/src/providers/prompt.rs
+++ b/src/providers/prompt.rs
@@ -6,14 +6,37 @@ use indoc::indoc;
 pub struct Prompt;
 
 impl Prompt {
-    pub const DEFAULT_ROLE: &str = "You are a senior engineer";
+    pub const DEFAULT_ROLE: &str = indoc! {
+        r#"You are a technical writer creating PR summaries."#
+    };
     pub const DEFAULT_DIRECTIVE: &str = indoc! {
-        r#"Analyze this git diff and create a concise PR description. Focus on:
-        - What changes were made (be specific but brief)
-        - Why these changes matter
-        - Any breaking changes or important notes, assuming there are any. If not, don't mention it.
-        Keep it under 150 words and use bullet points for clarity. Don't include implementation details unless critical.
-        Don't unclude your own thought process. The output should be just the content of the PR summary."#
+        r#"Write a professional summary of the changes made in the diff. Start directly with the summary, no conversational preamble.
+        Use markdown syntax. Mention any breaking changes. Do not write code. Use the following as an example template. Do not check boxes which are not
+        included in the diff.
+
+        START
+        # Pull Request
+
+        ## Summary
+        Brief description of what this PR accomplishes.
+
+        ## Changes Made
+        - List the main changes
+        - Use bullet points for clarity
+        - Be specific about what was modified
+
+        ## Type of Change
+        Feature, Bug, Chore, Docs
+
+
+        ## Breaking Changes
+        List any breaking changes and migration steps if applicable.
+
+        ## Additional Notes
+        Any additional context, considerations, or follow-up items.
+        END
+
+        "#
     };
 
     pub const DEFAULT_TITLE_DIRECTIVE: &str = indoc! {
@@ -39,12 +62,14 @@ impl Prompt {
         };
 
         Ok(format!(
-            indoc! {"[CONTEXT]
-            {diff}
+            indoc! {"
             [ROLE]
             {role}
             [DIRECTIVE]
-            {directive}"},
+            {directive}
+            [DIFF]
+            {diff}
+            "},
             diff = Self::get_git_diff(base, head, exclude)?,
             role = role.unwrap_or(Self::DEFAULT_ROLE),
             directive = directive.unwrap_or(default_directive)


### PR DESCRIPTION
The changes made in this diff primarily involve updating the prompt used for generating pull request summaries. Here's a breakdown:

*   **Role Update:** The `DEFAULT_ROLE` constant has been updated to "You are a technical writer creating PR summaries." This change reflects a shift in the intended persona for the prompt.
*   **Directive Update:** The `DEFAULT_DIRECTIVE` constant has been significantly revised. The new directive provides a more structured template for the PR summary, including sections for "Summary," "Changes Made," "Type of Change," "Breaking Changes," and "Additional Notes." It emphasizes markdown syntax and discourages conversational preamble.  The directive also explicitly instructs the model *not* to write code.
*   **Prompt Formatting:** The format of the prompt being constructed in the `create_prompt` function has been altered to include `[DIFF]` after `[DIRECTIVE]`. This places the git diff content directly after the directive, which might influence how the model processes the information.
*   **Indoc Usage:** The use of `indoc!` has been expanded to improve readability of the constants.

These changes aim to improve the quality and structure of the generated PR summaries by providing a more specific and detailed set of instructions to the language model. The shift to a technical writer role and the structured template should lead to more professional and informative summaries.