### PR TITLE
4-add-option-of-providing-pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Summary
+
+<!---
+What type of change is this? eg.: bug fix, new feature, code cleanup, refactoring, etc.
+Clearly and concisely describe the goal of this change.
+-->
+
+## Description
+
+<!---
+* How does this achieve its goal?
+
+### Example checklist (feel free to keep only the bullet points that are relevant for this change):
+* Leave code comments documenting why you made the decisions you made
+* Review your diff one last time before submitting the pull request
+* Make sure the build passes before requesting review
+* What did you learn while building this?
+* Are there any pitfalls or caveats associated with this change?
+* Any pending items left for the future?
+* Did you encounter any existing code issues (tech debt, code smell, etc.)?
+* If you have added a new environment variable, did you add it to `.env.example`?
+-->
+
+## Test plan
+
+<!---
+Things to consider:
+
+* Did you write both unit and integration tests?
+* Did you make sure that test coverage % has not decreased with this change?
+-->
+
+Which steps did you take to test this change? (check at least one/all that apply)
+
+* [ ] Wrote unit tests
+* [ ] Tested manually in development
+* [ ] Tested manually in Heroku review app/staging
+* [ ] Other (specify)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "walkdir",
 ]
 
 [[package]]
@@ -1579,6 +1580,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2069,6 +2079,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,6 +2201,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ lazy_static = "1"
 secrecy = { version = "0.10", features = ["serde"] }
 indicatif = { version = "0.17.11", features = ["tokio"] }
 rand = "0.9.1"
+walkdir = "2.5.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -13,6 +13,7 @@ pub struct Request {
     pub base: String,
     pub head: String,
     pub exclude: String,
+    pub template: Option<String>,
     pub role: Option<String>,
     pub directive: Option<String>,
     pub is_title: bool,
@@ -31,6 +32,7 @@ pub trait Provider {
             request.exclude.as_str(),
             request.role.as_deref(),
             request.directive.as_deref(),
+            request.template.as_deref(),
             request.is_title,
         )?;
         trace!("Prompt:\n{prompt}");


### PR DESCRIPTION
## Summary

This is a new feature that adds pull request template support to the CLI tool, allowing users to provide custom PR templates for AI-generated summaries.

## Description

* Adds a new `walkdir` dependency to traverse the `.github` directory
* Implements automatic detection of `pull_request_template.md` files in the `.github` directory
* Adds a new `--template` CLI argument that accepts a custom template file path
* Modifies the prompt generation system to include template content in AI requests
* Refactors the default prompt structure by separating the template from the directive
* Updates the `Request` struct and `Provider` trait to handle template data
* Includes a GitHub pull request template file as part of the repository setup

### Key changes:
* New `default_pr_template()` function automatically discovers PR templates
* Template content is read from file and passed to the AI provider
* The prompt now includes a `[PULL_REQUEST_TEMPLATE]` section
* Default template moved from directive to separate constant for better organization

## Test plan

Which steps did you take to test this change? (check at least one/all that apply)

* [ ] Wrote unit tests
* [x] Tested manually in development
* [ ] Other (specify)
