### PR TITLE
18-fix---exclude-flag-for-multiple-inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "prai"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prai"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/theelderbeever/prai-cli"

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ struct Args {
 
     /// File patterns to ignore in the git diff
     #[arg(short, long, default_value = ":!*.lock")]
-    exclude: String,
+    exclude: Vec<String>,
 
     /// The provider profile to use for generation. Will default to the value in the config default.
     #[arg(short, long, global = true)]
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
         .init();
 
     debug!("Using commit1: {}, commit2: {:?}", args.minus, args.plus);
-    debug!("Exclude pattern: {}", args.exclude);
+    debug!("Exclude pattern: {:?}", args.exclude);
 
     let settings = Settings::from_path(&args.config)?;
     let profile = settings.get(args.profile.clone())?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,7 +12,7 @@ use log::trace;
 pub struct Request {
     pub base: String,
     pub head: String,
-    pub exclude: String,
+    pub exclude: Vec<String>,
     pub template: Option<String>,
     pub role: Option<String>,
     pub directive: Option<String>,
@@ -26,10 +26,11 @@ pub trait Provider {
 
     /// Build the prompt from the request parameters
     fn build_prompt(&self, request: &Request) -> Result<String> {
+        let exclusions: Vec<&str> = request.exclude.iter().map(|s| s.as_str()).collect();
         let prompt = prompt::Prompt::render(
             request.base.as_str(),
             request.head.as_str(),
-            request.exclude.as_str(),
+            &exclusions,
             request.role.as_deref(),
             request.directive.as_deref(),
             request.template.as_deref(),

--- a/src/providers/prompt.rs
+++ b/src/providers/prompt.rs
@@ -46,7 +46,7 @@ impl Prompt {
     pub fn render(
         base: &str,
         head: &str,
-        exclude: &str,
+        exclude: &[&str],
         role: Option<&str>,
         directive: Option<&str>,
         template: Option<&str>,
@@ -76,12 +76,12 @@ impl Prompt {
         ))
     }
 
-    fn get_git_diff(base: &str, head: &str, exclude: &str) -> Result<String> {
+    fn get_git_diff(base: &str, head: &str, exclude: &[&str]) -> Result<String> {
         let mut cmd = Command::new("git");
 
         cmd.arg("diff").arg(base).arg(head);
 
-        let output = cmd.args(["--", exclude]).output()?;
+        let output = cmd.args(["--", &exclude.join(" ")]).output()?;
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     fn test_prompt() {
-        let prompt = Prompt::render("683ddd6", "d2bbcc5", ":!*.lock", None, None, None, false)
+        let prompt = Prompt::render("683ddd6", "d2bbcc5", &[":!*.lock"], None, None, None, false)
             .unwrap()
             .replace(" \n", "\n");
 

--- a/src/providers/prompt.rs
+++ b/src/providers/prompt.rs
@@ -112,11 +112,35 @@ mod tests {
             .unwrap()
             .replace(" \n", "\n");
 
-        assert_str_eq!(EXPECTED, prompt.as_str());
+        assert_str_eq!(EXPECTED.trim(), prompt.as_str().trim());
     }
 
     const EXPECTED: &str = indoc! {
-        r#"[CONTEXT]
+        r#"[ROLE]
+        You are a technical writer creating PR summaries.
+        [DIRECTIVE]
+        Write a professional summary of the changes made in the diff. Start directly with the summary, no conversational preamble.
+        Use markdown syntax. Mention any breaking changes. Do not write code. Use the following as an example template. Do not check boxes which are not
+        included in the diff.
+        [PULL_REQUEST_TEMPLATE]
+        # Summary
+        Brief description of what this PR accomplishes.
+
+        ## Changes Made
+        - List the main changes
+        - Use bullet points for clarity
+        - Be specific about what was modified
+
+        ## Type of Change
+        Feature, Bug, Chore, Docs
+
+
+        ## Breaking Changes
+        List any breaking changes and migration steps if applicable.
+
+        ## Additional Notes
+        Any additional context, considerations, or follow-up items.
+        [DIFF]
         diff --git a/src/main.rs b/src/main.rs
         index 88f8b72..935c050 100644
         --- a/src/main.rs
@@ -189,15 +213,6 @@ mod tests {
                  .json(&request_body)
                  .send()
                  .await?;
-
-        [ROLE]
-        You are a senior engineer
-        [DIRECTIVE]
-        Analyze this git diff and create a concise PR description. Focus on:
-        - What changes were made (be specific but brief)
-        - Why these changes matter
-        - Any breaking changes or important notes
-        Keep it under 150 words and use bullet points for clarity. Don't include implementation details unless critical.
-        Don't unclude your own thought process. The output should be just the content of the PR summary."#
+                "#
     };
 }


### PR DESCRIPTION
## Summary

Version bump and enhancement to support multiple file exclusion patterns in git diff operations.

## Description

This change upgrades the package from version 0.2.0 to 0.3.0 and modifies the `exclude` parameter to accept multiple file patterns instead of a single pattern string.

### Key changes made:
* Updated package version in Cargo.toml from 0.2.0 to 0.3.0
* Changed `exclude` field type from `String` to `Vec<String>` across the codebase
* Modified command-line argument parsing to accept multiple exclusion patterns
* Updated git diff command construction to handle multiple exclusion patterns by joining them with spaces
* Enhanced debug logging to display the full list of exclusion patterns
* Updated test cases to use array syntax for exclusion patterns

### Breaking Changes
⚠️ **Breaking Change**: The `exclude` parameter now expects a vector of strings instead of a single string. Users will need to update their code to pass exclusion patterns as an array.

## Test plan

Which steps did you take to test this change? (check at least one/all that apply)

* [ ] Wrote unit tests
* [x] Tested manually in development
* [ ] Other (specify)

