### PR TITLE
20-anthropic-doesnt-work-with-temperature-and-top_p-set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "prai"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prai"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/theelderbeever/prai-cli"

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn main() -> Result<()> {
         }
     }?;
     pb.finish_and_clear();
-    println!("{}", description);
+    println!("{description}");
 
     Ok(())
 }

--- a/src/providers/google.rs
+++ b/src/providers/google.rs
@@ -11,7 +11,7 @@ impl Provider for GoogleProvider {
     type Config = GoogleSettings;
 
     fn from_config(config: Self::Config) -> Self {
-        debug!("Create Google provider from {:?}", config);
+        debug!("Create Google provider from {config:?}");
         Self { config }
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -57,12 +57,15 @@ pub trait Provider {
     /// Make the HTTP request (default implementation)
     fn make_http_request(&self, url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
         let client = self.get_client();
+        log::debug!("{body:?}");
         let response = client.post(url).json(body).send()?;
 
         if !response.status().is_success() {
+            let status = response.status();
+            log::error!("{}", response.text()?);
             return Err(anyhow::anyhow!(
                 "API request failed with status: {}",
-                response.status()
+                status
             ));
         }
 
@@ -71,7 +74,7 @@ pub trait Provider {
 
     /// Main request method with default implementation using the other trait methods
     fn make_request(&self, request: Request) -> Result<String> {
-        trace!("{:?}", request);
+        trace!("{request:?}");
 
         let prompt = self.build_prompt(&request)?;
         let url = self.build_url();

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -63,10 +63,7 @@ pub trait Provider {
         if !response.status().is_success() {
             let status = response.status();
             log::error!("{}", response.text()?);
-            return Err(anyhow::anyhow!(
-                "API request failed with status: {}",
-                status
-            ));
+            return Err(anyhow::anyhow!("API request failed with status: {status}",));
         }
 
         Ok(response.json()?)

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -9,7 +9,7 @@ pub struct OllamaProvider {
 impl Provider for OllamaProvider {
     type Config = OllamaSettings;
     fn from_config(config: Self::Config) -> Self {
-        debug!("Create provider from {:?}", config);
+        debug!("Create provider from {config:?}");
         Self { config }
     }
     fn build_url(&self) -> String {

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -11,7 +11,7 @@ impl Provider for OpenAIProvider {
     type Config = OpenAISettings;
 
     fn from_config(config: Self::Config) -> Self {
-        debug!("Create OpenAI provider from {:?}", config);
+        debug!("Create OpenAI provider from {config:?}");
         Self { config }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -38,7 +38,7 @@ impl Settings {
     }
 }
 
-fn serialize_secret<S>(_value: &SecretString, s: S) -> Result<S::Ok, S::Error>
+pub fn serialize_secret<S>(_value: &SecretString, s: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
@@ -63,7 +63,7 @@ pub enum Provider {
     Google(GoogleSettings),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AnthropicSettings {
     #[serde(default = "AnthropicSettings::default_version")]
     pub version: String,
@@ -72,10 +72,10 @@ pub struct AnthropicSettings {
     pub api_key: SecretString,
     #[serde(default = "AnthropicSettings::default_max_tokens")]
     pub max_tokens: u32,
-    #[serde(default = "AnthropicSettings::default_temperature")]
-    pub temperature: f32,
-    #[serde(default = "AnthropicSettings::default_top_p")]
-    pub top_p: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
 }
 
 impl AnthropicSettings {
@@ -85,14 +85,6 @@ impl AnthropicSettings {
 
     fn default_max_tokens() -> u32 {
         500
-    }
-
-    fn default_temperature() -> f32 {
-        0.3
-    }
-
-    fn default_top_p() -> f32 {
-        0.9
     }
 }
 


### PR DESCRIPTION
## Summary

Code refactoring to improve string formatting consistency and enhance the Anthropic provider implementation with proper type safety and serialization.

## Description

This change includes several improvements:

* **String formatting refactoring**: Replaced manual string concatenation with Rust's inline formatting across multiple provider implementations and main.rs for better consistency and readability
* **Anthropic provider enhancements**:
  - Introduced strongly-typed `Payload`, `Message`, and `Role` structs with proper serialization/deserialization support
  - Refactored request body construction to use the new type-safe `Payload` struct instead of raw JSON
  - Made `temperature` and `top_p` fields optional in `AnthropicSettings` with conditional serialization
* **Improved error handling**: Added debug logging for request bodies and enhanced error logging to capture response text on API failures
* **Configuration changes**: Made `AnthropicSettings` cloneable and removed default values for `temperature` and `top_p` parameters, making them truly optional

### Notable changes:
* Added `Clone` trait to `AnthropicSettings`
* Made `serialize_secret` function public for potential reuse
* Enhanced HTTP error messages to include response body for better debugging

## Test plan

Which steps did you take to test this change? (check at least one/all that apply)

* [ ] Wrote unit tests
* [ ] Tested manually in development
* [ ] Other (specify)
